### PR TITLE
BUILD-5236 Rename vsts to azdo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ Detailed documentation of the above setups can be found in the [xtranet document
 # Sonar Cloud extension testing
 
 * [Azure DevOps pipeline "SonarCloud - simple"](https://dev.azure.com/sonar-testing/sonar-scanner-vsts-test/_build?definitionId=4)
-* [SonarCloud project "sonar-scanner-vsts-test"](https://sonarcloud.io/project/overview?id=SonarSource_sonar-scanner-vsts-test)
+* [SonarCloud project "sonar-scanner-azdo-test"](https://sonarcloud.io/project/overview?id=SonarSource_sonar-scanner-azdo-test)
 * [Custom Extension marketplace for testing pre-release extensions](https://marketplace.visualstudio.com/manage/publishers/sonar-testing)

--- a/azure-pipelines-sonarcloud-simple.yml
+++ b/azure-pipelines-sonarcloud-simple.yml
@@ -7,7 +7,7 @@ steps:
     SonarCloud: 'SonarCloud'
     organization: 'sonarsource'
     scannerMode: 'MSBuild'
-    projectKey: 'SonarSource_sonar-scanner-vsts-test'
+    projectKey: 'SonarSource_sonar-scanner-azdo-test'
     extraProperties: |
       sonar.verbose=true
       sonar.cs.vscoveragexml.reportsPaths=coverage.xml


### PR DESCRIPTION
This makes the SonarCloud project point [to the new location](https://sonarcloud.io/project/overview?id=SonarSource_sonar-scanner-azdo-test) 